### PR TITLE
prepare multiple dbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.csv

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ compact:
 #    make run query=get-breakdown-by-workflow window="-7 days" limit=35 offset=0
 run:
 	@sed "s/:unit/'$(unit)'/g; \
-	s/:window/$(if $(window), '$(window)', '-7 days')/g; \
+	s/:window/$(if $(window), '$(window)', '-1 year')/g; \
 	s/:workflow_id/$(if $(workflow_id),'$(workflow_id)',NULL)/g; \
 	s/:project_id/$(if $(project_id),'$(project_id)',NULL)/g; \
 	s/:limit/$(if $(limit),$(limit),15)/g; \

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ CONTAINER_NAME := $(shell openssl rand -base64 24 | tr -dc 'a-zA-Z0-9')
 
 setup: nuke create populate
 
+benchmark-baseline:
+	hyperfine --warmup 2 --export-csv baseline.csv \
+		'make run query=baseline'
+
 benchmark-queries:
 	hyperfine --warmup 2 --export-csv result-queries.csv \
 		'make run query=get-breakdown-by-workflow' \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ benchmark-events:
 		--parameter-list events 1,2,4,8,16 \
 		--parameter-list version 1,2 \
 		--command-name 'v{version} - events: {events}' \
-		'make DB_FILEPATH=~/.n8n/analytics-benchmark-events{events}-v{version}.sqlite run query=${query}' \
+		'make DB_FILEPATH=~/.n8n/analytics-benchmark-events{events}-v{version}.sqlite run query=${query}'
 
 setup-workflow-benchmark:
 	@parallel 'make DB_FILEPATH=~/.n8n/analytics-benchmark-wfs{1}-v{2}.sqlite setup workflows={1} compact version={2}' \
@@ -43,19 +43,19 @@ benchmark-workflows:
 		--parameter-list wfs 125,250,500,1000 \
 		--parameter-list version 1,2 \
 		--command-name 'v{version} - wfs: {wfs}' \
-		'make DB_FILEPATH=~/.n8n/analytics-benchmark-wfs{wfs}-v{version}.sqlite run query=${query}' \
+		'make DB_FILEPATH=~/.n8n/analytics-benchmark-wfs{wfs}-v{version}.sqlite run query=${query}'
 
-setup-workflow-projects:
+setup-projects-benchmark:
 	@parallel 'make DB_FILEPATH=~/.n8n/analytics-benchmark-projects{1}-v{2}.sqlite setup projects={1} compact version={2}' \
 	::: 50 100 200 400 800 \
 	::: 1 2
 
 benchmark-projects:
 	hyperfine --warmup 2 --export-csv result-projects-${query}.csv \
-		--parameter-list projects 125,250,500,1000 \
+		--parameter-list projects 50,100,200,400,800 \
 		--parameter-list version 1,2 \
 		--command-name 'v{version} - projects: {projects}' \
-		'make DB_FILEPATH=~/.n8n/analytics-benchmark-projects{projects}-v{version}.sqlite run query=${query}' \
+		'make DB_FILEPATH=~/.n8n/analytics-benchmark-projects{projects}-v{version}.sqlite run query=${query}'
 
 # Remove the benchmark DB.
 nuke:

--- a/benchmark-latency.sh
+++ b/benchmark-latency.sh
@@ -9,7 +9,7 @@
 
 DB_FILEPATH=$1
 UNIT="hour" 
-WINDOW="-7 days"
+WINDOW="-1 years"
 RANDOM_WORKFLOW_ID=$(sqlite3 "$DB_FILEPATH" "SELECT id FROM workflow_entity LIMIT 1;")
 RANDOM_PROJECT_ID=$(sqlite3 "$DB_FILEPATH" "SELECT id FROM project LIMIT 1;")
 COMPACTION_VERSION=$(sqlite3 "$DB_FILEPATH" "SELECT value FROM settings WHERE key = 'compaction_version';")

--- a/queries/populate-analytics-metadata.sql
+++ b/queries/populate-analytics-metadata.sql
@@ -1,10 +1,12 @@
 -- TODO: Should all columns be NOT NULL?
 CREATE TABLE analytics_metadata (
-  workflowId VARCHAR(16) UNIQUE NOT NULL,
-  workflowName VARCHAR(128),
-  projectId VARCHAR(36), -- TODO: project table
+  workflowId VARCHAR(16) PRIMARY KEY REFERENCES analytics_by_period (workflowId) ON DELETE CASCADE,
+  workflowName VARCHAR(128) NOT NULL,
+  projectId VARCHAR(36),
   projectName VARCHAR(255)
 );
+
+CREATE INDEX idx_analytics_metadata_project_id ON analytics_metadata(projectId);
 
 INSERT INTO analytics_metadata (workflowId, workflowName)
 SELECT DISTINCT
@@ -20,3 +22,4 @@ UPDATE analytics_metadata SET
 FROM shared_workflow sw
 JOIN project p ON sw.projectId = p.id
 WHERE analytics_metadata.workflowId = sw.workflowId;
+

--- a/queries/populate-analytics.sql
+++ b/queries/populate-analytics.sql
@@ -33,7 +33,7 @@ WHERE type = 'time_saved_min';
 
 CREATE TABLE analytics_by_period (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  workflowId VARCHAR(16) REFERENCES workflow_entity(id) ON DELETE SET NULL, -- preserve analytics on workflow deletion
+  workflowId VARCHAR(16), -- preserve analytics on workflow deletion
   type TEXT NOT NULL, -- see analytics.type
   count INTEGER NOT NULL, -- count of events within aggregation period
   periodUnit TEXT NOT NULL, -- unit of aggregation period: hour, day, week 


### PR DESCRIPTION
The idea is to then benchmark each query across different setups and compare how they behave for different schedules and different raw event counts:

```sh
parallel -j1 --quote  hyperfine --warmup 2 --runs 5 --export-csv {1}.csv --parameter-list rows_mm 1,2,4,8,16 --parameter-list version 1,2 --command-name {1} 'make DB_FILEPATH=~/.n8n/analytics-benchmark-{rows_mm}x-v{version}.sqlite run query={2}' \
	::: baseline get-breakdown get-periodic-total-executions get-periodic-total-failed-executions get-periodic-total-failure-rate \
	:::+ baseline "get-breakdown-by-workflow window=\"-7 days\"" "get-periodic-total-executions unit=hour window=\"-7 days\"" "get-periodic-total-failed-executions unit=hour window=\"-7 days\"" "get-periodic-total-failure-rate unit=hour window=\"-7 days\""
```

![image](https://github.com/user-attachments/assets/7c71be98-15f3-46e3-93e5-239535002ab2)
