### PR TITLE
fix randomization

### DIFF
--- a/randomize-workflow-ids.sh
+++ b/randomize-workflow-ids.sh
@@ -19,9 +19,9 @@ if [ ${#workflow_ids[@]} -eq 0 ]; then
   exit 1
 fi
 
-sql_stmt="UPDATE analytics SET workflowId = CASE"
+sql_stmt="UPDATE analytics SET workflowId = CASE ABS(RANDOM() % ${#workflow_ids[@]})"
 for i in "${!workflow_ids[@]}"; do
-    sql_stmt+=" WHEN (ABS(RANDOM()) % ${#workflow_ids[@]}) = $i THEN '${workflow_ids[$i]}'"
+    sql_stmt+=" WHEN $i THEN '${workflow_ids[$i]}'"
 done
 sql_stmt+=" ELSE '${workflow_ids[0]}' END;"
 


### PR DESCRIPTION
`RANDOM` creates negative values half the time, that led to the else branch being executed half the time to half of all events were attributed to the same wf.

Things are a bit slower with more distribution:

Before:
```
Benchmark 1: make run query=get-breakdown-by-workflow
  Time (mean ± σ):     361.1 ms ±   5.3 ms    [User: 288.4 ms, System: 74.6 ms]
  Range (min … max):   355.5 ms … 373.1 ms    10 runs
 
Benchmark 2: make run query=get-periodic-total-executions
  Time (mean ± σ):      75.6 ms ±   3.6 ms    [User: 54.9 ms, System: 24.0 ms]
  Range (min … max):    73.1 ms …  95.7 ms    38 runs
 
Benchmark 3: make run query=get-periodic-total-failed-executions
  Time (mean ± σ):      68.8 ms ±   1.1 ms    [User: 47.7 ms, System: 24.4 ms]
  Range (min … max):    65.1 ms …  70.6 ms    42 runs
 
Benchmark 4: make run query=get-periodic-total-failure-rate
  Time (mean ± σ):      49.0 ms ±   1.9 ms    [User: 30.1 ms, System: 22.4 ms]
  Range (min … max):    45.6 ms …  52.9 ms    60 runs
 
Benchmark 5: make run query=get-periodic-total-time-saved
  Time (mean ± σ):      65.6 ms ±   3.9 ms    [User: 45.8 ms, System: 23.2 ms]
  Range (min … max):    56.3 ms …  70.3 ms    41 runs
 
Benchmark 6: make run query=get-single-total-executions
  Time (mean ± σ):      54.7 ms ±   3.8 ms    [User: 38.7 ms, System: 19.0 ms]
  Range (min … max):    49.0 ms …  64.2 ms    44 runs
 
Benchmark 7: make run query=get-single-total-failed-executions
  Time (mean ± σ):      51.4 ms ±   3.1 ms    [User: 36.4 ms, System: 18.2 ms]
  Range (min … max):    46.1 ms …  58.5 ms    55 runs
 
Benchmark 8: make run query=get-single-total-failure-rate
  Time (mean ± σ):      83.9 ms ±   8.6 ms    [User: 61.9 ms, System: 25.1 ms]
  Range (min … max):    70.9 ms …  97.8 ms    31 runs
 
Benchmark 9: make run query=get-single-total-time-saved
  Time (mean ± σ):      42.1 ms ±   3.6 ms    [User: 28.5 ms, System: 16.5 ms]
  Range (min … max):    36.7 ms …  51.7 ms    70 runs
```

After:
```
Benchmark 1: make run query=get-breakdown-by-workflow
  Time (mean ± σ):     440.5 ms ±   2.5 ms    [User: 359.8 ms, System: 82.5 ms]
  Range (min … max):   436.2 ms … 443.7 ms    10 runs
 
Benchmark 2: make run query=get-periodic-total-executions
  Time (mean ± σ):      86.9 ms ±   1.5 ms    [User: 68.3 ms, System: 21.9 ms]
  Range (min … max):    85.0 ms …  93.2 ms    33 runs
 
Benchmark 3: make run query=get-periodic-total-failed-executions
  Time (mean ± σ):      64.0 ms ±   7.9 ms    [User: 45.6 ms, System: 21.6 ms]
  Range (min … max):    52.2 ms …  81.2 ms    37 runs
 
Benchmark 4: make run query=get-periodic-total-failure-rate
  Time (mean ± σ):      40.8 ms ±   2.9 ms    [User: 25.0 ms, System: 18.8 ms]
  Range (min … max):    36.6 ms …  49.2 ms    65 runs
 
Benchmark 5: make run query=get-periodic-total-time-saved
  Time (mean ± σ):      70.5 ms ±   3.8 ms    [User: 49.4 ms, System: 24.3 ms]
  Range (min … max):    63.5 ms …  76.5 ms    44 runs
 
Benchmark 6: make run query=get-single-total-executions
  Time (mean ± σ):      61.2 ms ±   5.5 ms    [User: 45.9 ms, System: 18.3 ms]
  Range (min … max):    51.8 ms …  73.8 ms    40 runs
 
Benchmark 7: make run query=get-single-total-failed-executions
  Time (mean ± σ):      49.1 ms ±   1.6 ms    [User: 33.8 ms, System: 18.1 ms]
  Range (min … max):    45.5 ms …  52.8 ms    59 runs
 
Benchmark 8: make run query=get-single-total-failure-rate
  Time (mean ± σ):      80.9 ms ±   5.9 ms    [User: 60.4 ms, System: 23.3 ms]
  Range (min … max):    71.2 ms …  89.4 ms    34 runs
 
Benchmark 9: make run query=get-single-total-time-saved
  Time (mean ± σ):      42.1 ms ±   2.3 ms    [User: 29.7 ms, System: 15.1 ms]
  Range (min … max):    38.2 ms …  49.9 ms    68 runs
```
