### PR TITLE
simplify query

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ compact:
 #    make run query=get-breakdown-by-workflow window="-7 days" project_id=E0E058A25F43D1640267B4963CC5FE7A
 #    make run query=get-breakdown-by-workflow window="-7 days" limit=35 offset=0
 run:
-	@sed "s/:unit/'$(unit)'/g; \
+	sed "s/:unit/$(if $(unit),$(unit),'hour')/g; \
 	s/:window/$(if $(window), '$(window)', '-1 year')/g; \
 	s/:workflow_id/$(if $(workflow_id),'$(workflow_id)',NULL)/g; \
 	s/:project_id/$(if $(project_id),'$(project_id)',NULL)/g; \


### PR DESCRIPTION
before:
```
hyperfine --warmup 2 --export-csv result-queries.csv \
	'make run query=get-periodic-total-failure-rate' 
Benchmark 1: make run query=get-periodic-total-failure-rate
  Time (mean ± σ):     393.2 ms ±  11.5 ms    [User: 333.8 ms, System: 60.5 ms]
  Range (min … max):   384.0 ms … 424.6 ms    10 runs
```

after
```
hyperfine --warmup 2 --export-csv result-queries.csv \
	'make run query=get-periodic-total-failure-rate' 
Benchmark 1: make run query=get-periodic-total-failure-rate
  Time (mean ± σ):     163.1 ms ±   7.1 ms    [User: 129.6 ms, System: 35.1 ms]
  Range (min … max):   154.9 ms … 173.2 ms    17 runs
```
